### PR TITLE
Update to use SLF4j, fixing crash on 1.18.2

### DIFF
--- a/src/main/java/de/guntram/mcmod/debug/TagDump.java
+++ b/src/main/java/de/guntram/mcmod/debug/TagDump.java
@@ -8,15 +8,15 @@ package de.guntram.mcmod.debug;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author gbl
  */
 public class TagDump {
-    static final Logger LOGGER = LogManager.getLogger(TagDump.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(TagDump.class);
 
     public static void dump(NbtCompound tag, int indent) {
         StringBuilder res;
@@ -47,7 +47,7 @@ public class TagDump {
             } else {
                 res.append(s).append("(Type ").append(elem.getType()).append(")");
             }
-            LOGGER.info(res);
+            LOGGER.info(String.valueOf(res));
             if (elem.getType() == 10) {
                 dump(tag.getCompound(s), indent+1);
             }

--- a/src/main/java/de/guntram/mcmod/easiercrafting/BrewingRecipeRegistryCache.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/BrewingRecipeRegistryCache.java
@@ -1,7 +1,7 @@
 package de.guntram.mcmod.easiercrafting;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 
 public class BrewingRecipeRegistryCache {
 
-    private static final Logger LOGGER = LogManager.getLogger(BrewingRecipeRegistryCache.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrewingRecipeRegistryCache.class);
     private static List<BrewingRecipe> recipes = new ArrayList<>();
 
     public static void add(BrewingRecipe recipe) {

--- a/src/main/java/de/guntram/mcmod/easiercrafting/InventoryRecipeScanner.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/InventoryRecipeScanner.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class InventoryRecipeScanner {
     
-    private static final Logger LOGGER = LoggerFactory.getLogger();
+    private static final Logger LOGGER = LoggerFactory.getLogger(InventoryRecipeScanner.class);
     
     static List<Recipe> findUnusualRecipes(ScreenHandler inventory, int firstInventorySlotNo) {
         ArrayList<Recipe> result=new ArrayList<>();

--- a/src/main/java/de/guntram/mcmod/easiercrafting/InventoryRecipeScanner.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/InventoryRecipeScanner.java
@@ -24,8 +24,8 @@ import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.DyeColor;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class InventoryRecipeScanner {
     
-    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Logger LOGGER = LoggerFactory.getLogger();
     
     static List<Recipe> findUnusualRecipes(ScreenHandler inventory, int firstInventorySlotNo) {
         ArrayList<Recipe> result=new ArrayList<>();

--- a/src/main/java/de/guntram/mcmod/easiercrafting/LocalRecipeManager.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/LocalRecipeManager.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LocalRecipeManager extends RecipeManager implements ResourceManager {
     
-    private static final Logger LOGGER = LoggerFactory.getLogger();
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalRecipeManager.class);
     private static final Set<String> namespaces = Collections.singleton( EasierCrafting.MODID );
     private static final List<String> forcedZips = new ArrayList<>();
     private static final LocalRecipeManager instance = new LocalRecipeManager();
@@ -78,7 +78,7 @@ public class LocalRecipeManager extends RecipeManager implements ResourceManager
 
     public static void dumpAll() {
         for (Recipe r: instance.values()) {
-            LOGGER.info(r.getId());
+            LOGGER.info(r.getId().toString());
             // System.out.println(r.getId() + " produces " + r.getOutput().getTranslationKey());
         }
     }

--- a/src/main/java/de/guntram/mcmod/easiercrafting/LocalRecipeManager.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/LocalRecipeManager.java
@@ -31,8 +31,8 @@ import net.minecraft.resource.metadata.ResourceMetadataReader;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.profiler.SampleType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -40,7 +40,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class LocalRecipeManager extends RecipeManager implements ResourceManager {
     
-    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Logger LOGGER = LoggerFactory.getLogger();
     private static final Set<String> namespaces = Collections.singleton( EasierCrafting.MODID );
     private static final List<String> forcedZips = new ArrayList<>();
     private static final LocalRecipeManager instance = new LocalRecipeManager();

--- a/src/main/java/de/guntram/mcmod/easiercrafting/Loom/ExtendedGuiLoom.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/Loom/ExtendedGuiLoom.java
@@ -31,9 +31,9 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.lwjgl.glfw.GLFW;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -52,7 +52,7 @@ public class ExtendedGuiLoom extends LoomScreen implements SlotClickAccepter {
 
     public ExtendedGuiLoom(LoomScreenHandler container, PlayerInventory inventory, Text title) {
         super(container, inventory, title);
-        LOGGER=LogManager.getLogger();
+        LOGGER=LoggerFactory.getLogger(ExtendedGuiLoom.class);
     }
     
     @Override
@@ -217,7 +217,7 @@ public class ExtendedGuiLoom extends LoomScreen implements SlotClickAccepter {
             recipeBook.updateRecipes();
             recipeBook.updatePatternMatch();
         } catch (IOException ex) {
-            LOGGER.warn(ex);
+            LOGGER.warn(ex.toString());
         }
     }
     

--- a/src/main/java/de/guntram/mcmod/easiercrafting/Loom/LoomRecipeRegistry.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/Loom/LoomRecipeRegistry.java
@@ -12,8 +12,8 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.SortedSet;
 import java.util.TreeMap;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -28,7 +28,7 @@ public class LoomRecipeRegistry {
     
     private LoomRecipeRegistry() {
         recipes = new TreeMap<>();
-        LOGGER = LogManager.getLogger();
+        LOGGER = LoggerFactory.getLogger(LoomRecipeRegistry.class);
     }
     
     public static LoomRecipeRegistry getInstance() {

--- a/src/main/java/de/guntram/mcmod/easiercrafting/RecipeBook.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/RecipeBook.java
@@ -48,14 +48,13 @@ import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.MathHelper;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.lwjgl.glfw.GLFW;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RecipeBook {
     
-    public static final Logger LOGGER = LogManager.getLogger(RecipeBook.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(RecipeBook.class);
 
     public final HandledScreen screen;
     private final int firstCraftSlot;
@@ -324,8 +323,7 @@ public class RecipeBook {
         ScreenHandler inventory = screen.getScreenHandler();
         List<Recipe> recipes = new ArrayList<>();
         if (wantedRecipeType == BrewingRecipe.recipeType) {
-            Level level = Level.DEBUG;
-            LOGGER.log(level, "recipebook: size= "+inventory.slots.size());
+            LOGGER.debug("recipebook: size= "+inventory.slots.size());
 
             List<BrewingRecipe> potionRecipes = BrewingRecipeRegistryCache.registeredPotionRecipes();
             Set<BrewingRecipe> possiblePotionRecipes = new HashSet<>();
@@ -337,7 +335,7 @@ public class RecipeBook {
                 Potion potionType = PotionUtil.getPotion(stack);
                 if (!stack.isEmpty() && potionType != Potions.EMPTY) {
                     BrewingRecipe newRecipe;
-                    LOGGER.log(level, "slot "+i+" has "+stack.getCount()+" of "+stack.getItem().getName().getString() + " potion type "+potionType.finishTranslationKey(""));
+                    LOGGER.debug("slot "+i+" has "+stack.getCount()+" of "+stack.getItem().getName().getString() + " potion type "+potionType.finishTranslationKey(""));
                     for (BrewingRecipe br: itemRecipes) {
                         if (br.getInputPotion().getItem() == stack.getItem()) {
                             // This potion item can be converted to a different item.
@@ -347,7 +345,7 @@ public class RecipeBook {
                             ItemStack input  = new ItemStack(br.getInputPotion().getItem()); PotionUtil.setPotion(input, potionType);
                             ItemStack output = new ItemStack(br.getOutput().getItem()); PotionUtil.setPotion(output, potionType);
                             possibleItemRecipes.add(newRecipe = new BrewingRecipe(false, input, br.getIngredient(), output));
-                            LOGGER.log(level, "adding recipe "+newRecipe.toString());
+                            LOGGER.debug("adding recipe "+newRecipe.toString());
                         }
                     }
                     for (BrewingRecipe br: potionRecipes) {
@@ -355,7 +353,7 @@ public class RecipeBook {
                             ItemStack input = new ItemStack(stack.getItem()); PotionUtil.setPotion(input, potionType);
                             ItemStack output = new ItemStack(stack.getItem()); PotionUtil.setPotion(output, PotionUtil.getPotion(br.getOutput()));
                             possiblePotionRecipes.add(newRecipe = new BrewingRecipe(true, input, br.getIngredient(), output));
-                            LOGGER.log(level, "adding recipe "+newRecipe.toString());
+                            LOGGER.debug("adding recipe "+newRecipe.toString());
                         }
                     }
                 }
@@ -412,7 +410,7 @@ public class RecipeBook {
                 catRecipes=new RecipeTreeSet();
                 craftableCategories.put(category, catRecipes);
             }
-            LOGGER.log(Level.DEBUG, "adding "+result.getName().getString()+" in "+category);
+            LOGGER.debug("adding "+result.getName().getString()+" in "+category);
             catRecipes.add((Recipe)recipe);
         }
         recalcListSize();

--- a/src/main/java/de/guntram/mcmod/easiercrafting/mixins/BrewingstandRefreshMixin.java
+++ b/src/main/java/de/guntram/mcmod/easiercrafting/mixins/BrewingstandRefreshMixin.java
@@ -6,7 +6,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.packet.s2c.play.InventoryS2CPacket;
 import net.minecraft.network.packet.s2c.play.WorldEventS2CPacket;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 public class BrewingstandRefreshMixin {
     
-    @Shadow @Final static Logger LOGGER;
+    @Shadow @Final private static Logger LOGGER;
     
     @Inject(method="onInventory", at=@At("RETURN"))
     private void dumpInventoryInfo(InventoryS2CPacket packet, CallbackInfo ci) {


### PR DESCRIPTION
Will also require versionfiles changes and CrowdinTranslate changes (gbl/CrowdinTranslate#11) to compile properly, but this fixes a crash on 22w03a (`LOGGER` field in `BrewingstandRefreshMixin` changed signatures, breaking it on that version) and switches all loggers over to slf4j.